### PR TITLE
Correct the reporting of price, and the main equation in model_core

### DIFF
--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1911,11 +1911,11 @@ EMISSION_CONSTRAINT(node,type_emission,type_tec,type_year)$is_bound_emission(nod
 
 EMISSION_POOL_EQUIVALENCE(node,emission,type_tec,year)$is_emission_sink_rate(node,emission,type_tec,year)..
     EMISS_POOL(node,emission,type_tec,year) =G=
+    SUM(year_all2$( seq_period(year_all2,year) ),
 * emission pool from historical period if year == firstmodelyear
     historical_emission_pool(node,emission,type_tec,year_all2)$first_period(year)
 * emission pool from previous period if year != firstmodelyear
-    + SUM(year_all2$( seq_period(year_all2,year) ),
-         EMISS_POOL(node,emission,type_tec,year_all2)$(model_horizon(year_all2) AND NOT first_period(year))
+    + EMISS_POOL(node,emission,type_tec,year_all2)$(model_horizon(year_all2) AND NOT first_period(year))
 * emission additions in current period
     + duration_period(year) * EMISS(node,emission,type_tec,year)
     ) / (1 + emission_sink_rate(node,emission,type_tec,year) * duration_period(year))

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -60,14 +60,10 @@ EMISSION_CONSTRAINT.m(node,type_emission,type_tec,type_year)$(
     PRICE_EMISSION.l(node,type_emission,type_tec,year)$(
         PRICE_EMISSION.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
 
-* rescale the dual of the emission constraint to account that the constraint is defined on the average year, not total
-EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)$(
-        EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year) ) =
-    EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year) / df_period(year) ;
-
+* rescale the dual of the emission pool constraint to account for the discount factor per period duration
     PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) =
                - EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)
-            /  duration_period(year);
+            *  df_period(year);
     PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year)$(
         PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
 

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -60,10 +60,14 @@ EMISSION_CONSTRAINT.m(node,type_emission,type_tec,type_year)$(
     PRICE_EMISSION.l(node,type_emission,type_tec,year)$(
         PRICE_EMISSION.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
 
-* rescale the dual of the emission pool constraint to account for the discount factor per period duration
-    PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) =
-               - EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)
-            *  df_period(year);
+* rescale the dual of the emission pool constraint to account for the discount factor and period duration
+EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)$(
+    EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)) =
+    EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year) / df_period(year);
+
+PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) =
+               - EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year) * duration_period(year)
+;
     PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year)$(
         PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
 


### PR DESCRIPTION
1- the price reporting corrected to scale the `PRICE_EMISSION_POOL` based on periodic discount factor (`df_period`). This way the reported prices are per period, and not per year, which should be consistent with the `tax_emission_pool`.
2. A minor issue in the `model_core` equations for in `EMISSION_POOL_EQUIVALENCE` makes an error. The mapping of the years should be on top of equations.
