### PR TITLE
Implement lower and upper bounds for emission pooling

### DIFF
--- a/message_ix/model/MESSAGE/data_load.gms
+++ b/message_ix/model/MESSAGE/data_load.gms
@@ -52,7 +52,8 @@ rating_bin, reliability_factor, peak_load_factor, flexibility_factor
 renewable_capacity_factor, renewable_potential
 * emission factors, bounds and taxes on emissions (including mapping sets)
 historical_emission, emission_factor, emission_scaling, is_bound_emission, bound_emission, tax_emission,
-emission_sink_rate, is_emission_sink_rate, historical_emission_pool, tax_emission_pool, is_bound_emission_pool, bound_emission_pool,
+emission_sink_rate, is_emission_sink_rate, historical_emission_pool, tax_emission_pool,
+bound_emission_pool_up, is_bound_emission_pool_up, bound_emission_pool_lo, is_bound_emission_pool_lo, 
 * historical values of new capacity investment, activity and extraction
 historical_new_capacity, historical_activity, historical_extraction
 * parameters for land-use model emulator

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -115,15 +115,12 @@ Variables
     COST_NODAL(node, year_all)                   system costs at the node level over time
 * auxiliary variable for aggregate emissions by technology type and land-use model emulator
     EMISS(node,emission,type_tec,year_all)       aggregate emissions by technology type and land-use model emulator
+* regional emission pool
+    EMISS_POOL(node,emission,type_tec,year_all)  nodal-regional-global emission pool size
 * auxiliary variable for left-hand side of relations (linear constraints)
     REL(relation,node,year_all)                  auxiliary variable for left-hand side of user-defined relations
 * change in the content of storage device
     STORAGE_CHARGE(node,tec,level,commodity,year_all,time)    charging of storage in each timestep (negative for discharge)
-;
-
-Positive variables
-* regional emission pool
-    EMISS_POOL(node,emission,type_tec,year_all)          nodal-regional-global emission pool size
 ;
 
 ***
@@ -280,7 +277,8 @@ Equations
     EMISSION_EQUIVALENCE            auxiliary equation to simplify the notation of emissions
     EMISSION_CONSTRAINT             nodal-regional-global constraints on emissions (by category)
     EMISSION_POOL_EQUIVALENCE       nodal-regional-global emission pool with carbon sink rate
-    EMISSION_POOL_CONSTRAINT        nodal-regional-global constraints on emission pool (by type)
+    EMISSION_POOL_CONSTRAINT_UP     nodal-regional-global upper bound on emission pool (by type)
+    EMISSION_POOL_CONSTRAINT_LO     nodal-regional-global lower bound on emission pool (by type)
     LAND_CONSTRAINT                 constraint on total land use (linear combination of land scenarios adds up to 1)
     DYNAMIC_LAND_SCEN_CONSTRAINT_UP dynamic constraint on land scenario change (upper bound)
     DYNAMIC_LAND_SCEN_CONSTRAINT_LO dynamic constraint on land scenario change (lower bound)
@@ -1922,28 +1920,51 @@ EMISSION_POOL_EQUIVALENCE(node,emission,type_tec,year)$is_emission_sink_rate(nod
 ;
 
 ***
-* Bound on emission pool
+* Upper bound on emission pool
 * ^^^^^^^^^^^^^^^^^^^^^^
 *
-* .. _emission_pool_constraint:
+* .. _emission_pool_constraint_up:
 *
-* Equation EMISSION_POOL_CONSTRAINT
+* Equation EMISSION_POOL_CONSTRAINT_UP
 * """""""""""""""""""""""""""""""""
 * This constraint enforces upper bounds on the emission pool.
 *
 *   .. math::
 *          \sum_{e \in E(\widehat{e})}
 *                  emission\_scaling_{\widehat{e},e} \cdot EMISS\_POOL_{n,e,\widehat{t},y}
-*      \leq bound\_emission\_pool_{n,\widehat{e},\widehat{t},y}
+*      \leq bound\_emission\_pool\_up_{n,\widehat{e},\widehat{t},y}
 *
 ***
-EMISSION_POOL_CONSTRAINT(node,type_emission,type_tec,year)$is_bound_emission_pool(node,type_emission,type_tec,year)..
+
+EMISSION_POOL_CONSTRAINT_UP(node,type_emission,type_tec,year)$is_bound_emission_pool_up(node,type_emission,type_tec,year)..
     SUM( (emission)$( cat_emission(type_emission,emission) ),
         emission_scaling(type_emission,emission)
         * EMISS_POOL(node,emission,type_tec,year)
       )
-    =L= bound_emission_pool(node,type_emission,type_tec,year) ;
+    =L= bound_emission_pool_up(node,type_emission,type_tec,year) ;
 
+***
+* Lower bound on emission pool
+* ^^^^^^^^^^^^^^^^^^^^^^
+*
+* .. _emission_pool_constraint_lo:
+*
+* Equation EMISSION_POOL_CONSTRAINT_LO
+* """""""""""""""""""""""""""""""""
+* This constraint enforces upper bounds on the emission pool.
+*
+*   .. math::
+*          \sum_{e \in E(\widehat{e})}
+*                  emission\_scaling_{\widehat{e},e} \cdot EMISS\_POOL_{n,e,\widehat{t},y}
+*      \geq bound\_emission\_pool\_lo_{n,\widehat{e},\widehat{t},y}
+*
+***
+EMISSION_POOL_CONSTRAINT_LO(node,type_emission,type_tec,year)$is_bound_emission_pool_lo(node,type_emission,type_tec,year)..
+    SUM( (emission)$( cat_emission(type_emission,emission) ),
+        emission_scaling(type_emission,emission)
+        * EMISS_POOL(node,emission,type_tec,year)
+      )
+    =G= bound_emission_pool_lo(node,type_emission,type_tec,year) ;
 *----------------------------------------------------------------------------------------------------------------------*
 ***
 * .. _section_landuse_emulator:

--- a/message_ix/model/MESSAGE/model_core.gms
+++ b/message_ix/model/MESSAGE/model_core.gms
@@ -1908,7 +1908,7 @@ EMISSION_CONSTRAINT(node,type_emission,type_tec,type_year)$is_bound_emission(nod
 ***
 
 EMISSION_POOL_EQUIVALENCE(node,emission,type_tec,year)$is_emission_sink_rate(node,emission,type_tec,year)..
-    EMISS_POOL(node,emission,type_tec,year) =G=
+    EMISS_POOL(node,emission,type_tec,year) =E=
     SUM(year_all2$( seq_period(year_all2,year) ),
 * emission pool from historical period if year == firstmodelyear
     historical_emission_pool(node,emission,type_tec,year_all2)$first_period(year)

--- a/message_ix/model/MESSAGE/model_solve.gms
+++ b/message_ix/model/MESSAGE/model_solve.gms
@@ -61,15 +61,15 @@ EMISSION_CONSTRAINT.m(node,type_emission,type_tec,type_year)$(
         PRICE_EMISSION.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
 
 * rescale the dual of the emission pool constraint to account for the discount factor and period duration
-EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)$(
-    EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year)) =
-    EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year) / df_period(year);
+EMISSION_POOL_CONSTRAINT_UP.m(node,type_emission,type_tec,year)$(
+    EMISSION_POOL_CONSTRAINT_UP.m(node,type_emission,type_tec,year)) =
+    EMISSION_POOL_CONSTRAINT_UP.m(node,type_emission,type_tec,year) / df_period(year);
 
 PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) =
-               - EMISSION_POOL_CONSTRAINT.m(node,type_emission,type_tec,year) * duration_period(year)
+               - EMISSION_POOL_CONSTRAINT_UP.m(node,type_emission,type_tec,year) * duration_period(year)
 ;
-    PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year)$(
-        PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
+PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year)$(
+    PRICE_EMISSION_POOL.l(node,type_emission,type_tec,year) = - inf ) = 0 ;
 
 %AUX_BOUNDS% AUX_ACT_BOUND_LO(node,tec,year_all,year_all2,mode,time)$( ACT.l(node,tec,year_all,year_all2,mode,time) < 0 AND
 %AUX_BOUNDS%    ACT.l(node,tec,year_all,year_all2,mode,time) = -%AUX_BOUND_VALUE% ) = yes ;

--- a/message_ix/model/MESSAGE/parameter_def.gms
+++ b/message_ix/model/MESSAGE/parameter_def.gms
@@ -594,7 +594,9 @@ Parameters
 *      - ``node`` | ``emission`` | ``type_tec`` | ``year``
 *    * - tax_emission_pool
 *      - ``node`` | ``type_emission`` | ``type_tec`` | ``year``
-*    * - bound_emission_pool
+*    * - bound_emission_pool_up
+*      - ``node`` | ``type_emission`` | ``type_tec`` | ``type``
+*    * - bound_emission_pool_lo
 *      - ``node`` | ``type_emission`` | ``type_tec`` | ``type``
 *
 * .. [#em_scaling] The parameter ``emission_scaling`` is the scaling factor to harmonize bounds or taxes across types of
@@ -610,7 +612,8 @@ Parameters
     emission_sink_rate(node,emission,type_tec,year_all)      emission sink rate for regional emission pool formulation
     historical_emission_pool(node,emission,type_tec,year_all) historical size of emission pool by technology type
     tax_emission_pool(node,type_emission,type_tec,year_all)  emission pool tax
-    bound_emission_pool(node,type_emission,type_tec,year_all) upper bound on emission pool size
+    bound_emission_pool_up(node,type_emission,type_tec,year_all) upper bound on emission pool size
+    bound_emission_pool_lo(node,type_emission,type_tec,year_all) lower bound on emission pool size
 ;
 
 *----------------------------------------------------------------------------------------------------------------------*

--- a/message_ix/model/MESSAGE/sets_maps_def.gms
+++ b/message_ix/model/MESSAGE/sets_maps_def.gms
@@ -443,7 +443,8 @@ Sets
 
     is_bound_emission(node,type_emission,type_tec,type_year) flag whether emissions bound exists
     is_emission_sink_rate(node,emission,type_tec,year_all) flag whether emission sink rate exists for regional emission pool formulation
-    is_bound_emission_pool(node,type_emission,type_tec,year_all) flag whether emission pool bound exists for regional emission pool formulation
+    is_bound_emission_pool_up(node,type_emission,type_tec,year_all) flag whether upper emission pool bound exists for regional emission pool formulation
+    is_bound_emission_pool_lo(node,type_emission,type_tec,year_all) flag whether lower emission pool bound exists for regional emission pool formulation
 
     is_dynamic_land_scen_up(node,land_scenario,year_all)   flag whether dynamic upper constraint on land-scenario change exists
     is_dynamic_land_scen_lo(node,land_scenario,year_all)   flag whether dynamic lower constraint on land-scenario change exists

--- a/message_ix/models.py
+++ b/message_ix/models.py
@@ -114,7 +114,10 @@ MESSAGE_ITEMS = {
     "cat_relation": item("set", "type_relation relation"),
     "cat_tec": item("set", "type_tec t"),
     "cat_year": item("set", "type_year y"),
-    "is_bound_emission_pool": dict(
+    "is_bound_emission_pool_up": dict(
+        ix_type="set", idx_sets=["node", "type_emission", "type_tec", "year"]
+    ),
+    "is_bound_emission_pool_lo": dict(
         ix_type="set", idx_sets=["node", "type_emission", "type_tec", "year"]
     ),
     "is_emission_sink_rate": dict(
@@ -157,9 +160,12 @@ MESSAGE_ITEMS = {
     "bound_activity_lo": item("par", "nl t ya m h"),
     "bound_activity_up": item("par", "nl t ya m h"),
     "bound_emission": item("par", "n type_emission type_tec type_year"),
-    "bound_emission_pool": dict(
+    "bound_emission_pool_up": dict(
         ix_type="par", idx_sets=["node", "type_emission", "type_tec", "year"]
     ),
+    "bound_emission_pool_lo": dict(
+        ix_type="par", idx_sets=["node", "type_emission", "type_tec", "year"]
+    ),    
     "bound_extraction_up": item("par", "n c g y"),
     "bound_new_capacity_lo": item("par", "nl t yv"),
     "bound_new_capacity_up": item("par", "nl t yv"),
@@ -427,7 +433,9 @@ class MESSAGE(GAMSModel):
         # handled in JDBCBackend. For the moment, this code does not backstop that
         # behaviour.
         # TODO Extend to handle all masks, e.g. for new backends.
-        for par_name in ("bound_emission_pool", "emission_sink_rate"):
+        for par_name in ("bound_emission_pool_up",
+                         "bound_emission_pool_lo",
+                         "emission_sink_rate"):
             # Name of the corresponding set
             set_name = f"is_{par_name}"
 

--- a/message_ix/tests/test_emission_pool.py
+++ b/message_ix/tests/test_emission_pool.py
@@ -191,7 +191,7 @@ def test_tax_emission_pool_world(test_mp):
     pdt.assert_frame_equal(exp, obs, check_dtype=False)
 
 
-def test_bound_emission_pool(test_mp):
+def test_bound_emission_pool_up(test_mp):
     s = make_westeros(test_mp, quiet=True)
     prep_scenario(s, test_mp)
 
@@ -206,8 +206,8 @@ def test_bound_emission_pool(test_mp):
             "unit": "???",
         }
     )
-    s.add_par("bound_emission_pool", df)
-    s.commit("bound_emission_pool added")
+    s.add_par("bound_emission_pool_up", df)
+    s.commit("bound_emission_pool_up added")
 
     s.solve()
 
@@ -242,7 +242,7 @@ def test_bound_emission_pool(test_mp):
     pdt.assert_frame_equal(exp, obs, check_dtype=False)
 
 
-def test_bound_emission_pool_removal(test_mp):
+def test_bound_emission_pool_lo(test_mp):
     s = make_westeros(test_mp, quiet=True)
     prep_scenario(s, test_mp)
 
@@ -257,31 +257,95 @@ def test_bound_emission_pool_removal(test_mp):
             "unit": "???",
         }
     )
-    s.add_par("bound_emission_pool", df)
-    s.commit("bound_emission_pool added")
+    s.add_par("bound_emission_pool_up", df)
+
+    df = pd.DataFrame(
+        {
+            "node": "Westeros",
+            "type_emission": "GHG",
+            "type_tec": "all",
+            "year": [710],
+            "value": [84000],
+            "unit": "???",
+        }
+    )
+    s.add_par("bound_emission_pool_lo", df)
+
+    s.commit("bound_emission_pool_lo and _up added")
+
+    s.solve()
+
+    exp = pd.DataFrame(
+        {
+            "node": "Westeros",
+            "emission": "CO2",
+            "type_tec": "all",
+            "year": [700, 710, 720],
+            "lvl": [86254.74797636835, 84000.0, 85000.0],
+            "mrg": 0.0,
+        }
+    )
+
+    obs = s.var("EMISS_POOL")
+
+    pdt.assert_frame_equal(exp, obs, check_dtype=False)
+
+    exp = pd.DataFrame(
+        {
+            "node": "Westeros",
+            "type_emission": "GHG",
+            "type_tec": "all",
+            "year": [720],
+            "lvl": [33.075572],
+            "mrg": 0.0,
+        }
+    )
+
+    obs = s.var("PRICE_EMISSION_POOL")
+
+    pdt.assert_frame_equal(exp, obs, check_dtype=False)
+
+
+def test_bound_emission_pool_up_removal(test_mp):
+    s = make_westeros(test_mp, quiet=True)
+    prep_scenario(s, test_mp)
+
+    s.check_out()
+    df = pd.DataFrame(
+        {
+            "node": "Westeros",
+            "type_emission": "GHG",
+            "type_tec": "all",
+            "year": [700, 710, 720],
+            "value": [87000, 86000, 85000],
+            "unit": "???",
+        }
+    )
+    s.add_par("bound_emission_pool_up", df)
+    s.commit("bound_emission_pool_up added")
 
     # Ensure that bound has been added
-    obs = s.par("bound_emission_pool")
+    obs = s.par("bound_emission_pool_up")
     pdt.assert_frame_equal(df, obs, check_dtype=False)
 
     s.solve()
 
     # Ensure that is_ set for bound has been added upon solving
     exp = df.drop(["value", "unit"], axis=1)
-    obs = s.set("is_bound_emission_pool")
+    obs = s.set("is_bound_emission_pool_up")
     pdt.assert_frame_equal(exp, obs, check_dtype=False)
 
     # Esnure that is_ set is removed when removing parameter
     s.remove_solution()
     s.check_out()
-    s.remove_par("bound_emission_pool", df)
+    s.remove_par("bound_emission_pool_up", df)
     s.commit("bound_emission_poll removed")
 
-    obs = s.set("is_bound_emission_pool")
+    obs = s.set("is_bound_emission_pool_up")
     assert obs.empty is True
 
 
-def test_bound_emission_pool_modification_inc_yrs(test_mp):
+def test_bound_emission_pool_up_modification_inc_yrs(test_mp):
     s = make_westeros(test_mp, quiet=True)
     prep_scenario(s, test_mp)
 
@@ -296,18 +360,18 @@ def test_bound_emission_pool_modification_inc_yrs(test_mp):
             "unit": "???",
         }
     )
-    s.add_par("bound_emission_pool", df)
-    s.commit("bound_emission_pool added")
+    s.add_par("bound_emission_pool_up", df)
+    s.commit("bound_emission_pool_up added")
 
     # Ensure that bound has been added
-    obs = s.par("bound_emission_pool")
+    obs = s.par("bound_emission_pool_up")
     pdt.assert_frame_equal(df, obs, check_dtype=False)
 
     s.solve()
 
     # Ensure that is_ set for bound has been added upon solving
     exp = df.drop(["value", "unit"], axis=1)
-    obs = s.set("is_bound_emission_pool")
+    obs = s.set("is_bound_emission_pool_up")
     pdt.assert_frame_equal(exp, obs, check_dtype=False)
 
     # Now check that when the dataframe is extended, if the "is_" set
@@ -324,22 +388,22 @@ def test_bound_emission_pool_modification_inc_yrs(test_mp):
             "unit": "???",
         }
     )
-    s.add_par("bound_emission_pool", df)
-    s.commit("bound_emission_pool added")
+    s.add_par("bound_emission_pool_up", df)
+    s.commit("bound_emission_pool_up added")
 
     # Ensure that bound has been added
-    obs = s.par("bound_emission_pool")
+    obs = s.par("bound_emission_pool_up")
     pdt.assert_frame_equal(df, obs, check_dtype=False)
 
     s.solve()
 
     # Ensure that is_ set for bound has been added upon solving
     exp = df.drop(["value", "unit"], axis=1)
-    obs = s.set("is_bound_emission_pool")
+    obs = s.set("is_bound_emission_pool_up")
     pdt.assert_frame_equal(exp, obs, check_dtype=False)
 
 
-def test_bound_emission_pool_modification_red_yrs(test_mp):
+def test_bound_emission_pool_up_modification_red_yrs(test_mp):
     s = make_westeros(test_mp, quiet=True)
     prep_scenario(s, test_mp)
 
@@ -354,18 +418,18 @@ def test_bound_emission_pool_modification_red_yrs(test_mp):
             "unit": "???",
         }
     )
-    s.add_par("bound_emission_pool", df)
-    s.commit("bound_emission_pool added")
+    s.add_par("bound_emission_pool_up", df)
+    s.commit("bound_emission_pool_up added")
 
     # Ensure that bound has been added
-    obs = s.par("bound_emission_pool")
+    obs = s.par("bound_emission_pool_up")
     pdt.assert_frame_equal(df, obs, check_dtype=False)
 
     s.solve()
 
     # Ensure that is_ set for bound has been added upon solving
     exp = df.drop(["value", "unit"], axis=1)
-    obs = s.set("is_bound_emission_pool")
+    obs = s.set("is_bound_emission_pool_up")
     pdt.assert_frame_equal(exp, obs, check_dtype=False)
 
     # Now check that when the dataframe is extended, if the "is_" set
@@ -374,8 +438,8 @@ def test_bound_emission_pool_modification_red_yrs(test_mp):
     s.check_out()
 
     # Remove existing
-    df = s.par("bound_emission_pool")
-    s.remove_par("bound_emission_pool", df)
+    df = s.par("bound_emission_pool_up")
+    s.remove_par("bound_emission_pool_up", df)
 
     df = pd.DataFrame(
         {
@@ -387,16 +451,16 @@ def test_bound_emission_pool_modification_red_yrs(test_mp):
             "unit": "???",
         }
     )
-    s.add_par("bound_emission_pool", df)
-    s.commit("bound_emission_pool added")
+    s.add_par("bound_emission_pool_up", df)
+    s.commit("bound_emission_pool_up added")
 
     # Ensure that bound has been added
-    obs = s.par("bound_emission_pool")
+    obs = s.par("bound_emission_pool_up")
     pdt.assert_frame_equal(df, obs, check_dtype=False)
 
     s.solve()
 
     # Ensure that is_ set for bound has been added upon solving
     exp = df.drop(["value", "unit"], axis=1)
-    obs = s.set("is_bound_emission_pool")
+    obs = s.set("is_bound_emission_pool_up")
     pdt.assert_frame_equal(exp, obs, check_dtype=False)

--- a/tutorial/westeros/westeros_emission_pools.ipynb
+++ b/tutorial/westeros/westeros_emission_pools.ipynb
@@ -254,7 +254,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## OPTIONAL: Add `bound_emission_pool`"
+    "## OPTIONAL: Add `bound_emission_pool_up`"
    ]
   },
   {
@@ -273,8 +273,7 @@
     "        'value': [87000, 86000, 85000],\n",
     "        'unit': '???'\n",
     "    })\n",
-    "    scen.add_par('bound_emission_pool', df)\n",
-    "            \n",
+    "    scen.add_par('bound_emission_pool_up', df)\n",
     "    # Remove bound_emission\n",
     "    df = scen.par('bound_emission')\n",
     "    scen.remove_par('bound_emission', df)\n",
@@ -357,7 +356,7 @@
     "#    710 78031.405954\n",
     "#    720 74315.624718\n",
     "\n",
-    "#    WITH `bound_emission_pool' EMISS_POOL should have results:\n",
+    "#    WITH `bound_emission_pool_up' EMISS_POOL should have results:\n",
     "#    700 87000\n",
     "#    710 85975.299326\n",
     "#    720 85000"

--- a/tutorial/westeros/westeros_emission_pools.ipynb
+++ b/tutorial/westeros/westeros_emission_pools.ipynb
@@ -15,22 +15,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "IPython.OutputArea.prototype._should_scroll = function(lines) { return false; }"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import ixmp\n",
@@ -43,7 +30,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +151,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,20 +302,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "221792.71875"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "scen.var('OBJ')['lvl']"
    ]
@@ -342,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,144 +340,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>node</th>\n",
-       "      <th>emission</th>\n",
-       "      <th>type_tec</th>\n",
-       "      <th>year</th>\n",
-       "      <th>lvl</th>\n",
-       "      <th>mrg</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Westeros</td>\n",
-       "      <td>CO2</td>\n",
-       "      <td>all</td>\n",
-       "      <td>700</td>\n",
-       "      <td>86254.747976</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Westeros</td>\n",
-       "      <td>CO2</td>\n",
-       "      <td>all</td>\n",
-       "      <td>710</td>\n",
-       "      <td>83545.115216</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Westeros</td>\n",
-       "      <td>CO2</td>\n",
-       "      <td>all</td>\n",
-       "      <td>720</td>\n",
-       "      <td>85000.000000</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       node emission type_tec  year           lvl  mrg\n",
-       "0  Westeros      CO2      all   700  86254.747976  0.0\n",
-       "1  Westeros      CO2      all   710  83545.115216  0.0\n",
-       "2  Westeros      CO2      all   720  85000.000000  0.0"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "scen.var('EMISS_POOL')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>node</th>\n",
-       "      <th>type_emission</th>\n",
-       "      <th>type_tec</th>\n",
-       "      <th>year</th>\n",
-       "      <th>lvl</th>\n",
-       "      <th>mrg</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>Westeros</td>\n",
-       "      <td>GHG</td>\n",
-       "      <td>all</td>\n",
-       "      <td>720</td>\n",
-       "      <td>33.075572</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "       node type_emission type_tec  year        lvl  mrg\n",
-       "0  Westeros           GHG      all   720  33.075572  0.0"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "scen.var('PRICE_EMISSION_POOL')"
    ]
@@ -515,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
- This PR does the following:
- removes the constraint in defining `EMISS_POOL` as a positive variable.
- adds a new parameter `bound_emission_pool_lo` for constraining the pool emissions with a lower bound.
- renames the existing `bound_emission_pool` to `bound_emission_pool_up` to be consistent with the name for the lower bound.
- updates inline documentation, GAMS code, jupyter tutorial, and `model.py` to reflect these additions and changes.